### PR TITLE
fix: stop retrying failed conversions indefinitely

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ WORKDIR=/app/downloads
 - `SLEEPTIME`: Time in seconds to wait before the next conversion cycle.
 - `WORKDIR`: Directory where the `.ts` files are located and where the converted `.mp4` files will be saved.
 
+### Failure handling
+
+The converter writes to a temporary `.mp4.part` file first. When conversion succeeds, the temporary file is moved to `.mp4` and the source `.ts` file is removed.
+
+If FFmpeg fails, the converter removes partial `.mp4` output and renames the source file from `video.ts` to `video.ts.failed`. This prevents restart policies from retrying the same failing file indefinitely.
+
+Large `.ts` files can require more than 256M of memory even when using `-c copy` remuxing. For large recordings, configure the container with at least 512M of memory or remove the memory limit.
+
 ### Build and Run the Docker Container
 
 Use Docker Compose to build and run the container:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,38 +1,63 @@
 #!/bin/sh
 
-# Exit immediately if a command exits with a non-zero status
-set -e
+# Exit on unexpected script errors, but handle ffmpeg conversion failures explicitly.
+set -eu
 
 # Set default values if environment variables are not provided
 : "${WORKDIR:=/app/downloads}"  # Define the working directory
 : "${SLEEPTIME:=600}"  # Define the SLEEPTIME in seconds
+: "${RUN_ONCE:=false}"  # Set to true for one-shot execution/tests
+
+mark_failed() {
+    ts_file="$1"
+    failed_file="${ts_file}.failed"
+
+    if [ -e "${failed_file}" ]; then
+        failed_file="${ts_file}.failed.$(date +%Y%m%d%H%M%S)"
+    fi
+
+    mv "${ts_file}" "${failed_file}"
+    echo "Marked failed conversion as '${failed_file}'."
+}
 
 convert_ts_to_mp4() {
     echo "Starting conversion of .ts files to .mp4 in ${WORKDIR}..."
+
+    mkdir -p "${WORKDIR}"
 
     # Find all .ts files in the WORKDIR
     find "${WORKDIR}" -type f -name "*.ts" | while read -r ts_file; do
         # Define the output .mp4 file path
         mp4_file="${ts_file%.ts}.mp4"
+        part_file="${mp4_file}.part"
 
         echo "Converting '${ts_file}' to '${mp4_file}'..."
 
-        # Perform the conversion using ffmpeg
-        ffmpeg -i "${ts_file}" -c copy "${mp4_file}" -y
+        rm -f "${part_file}"
 
-        if [ $? -eq 0 ]; then
+        # Perform the conversion using ffmpeg. Do not let failures exit the
+        # entrypoint before the source file and partial output are handled.
+        if ffmpeg -y -i "${ts_file}" -c copy -f mp4 "${part_file}" && mv "${part_file}" "${mp4_file}"; then
             echo "Successfully converted '${ts_file}' to '${mp4_file}'."
             rm "${ts_file}"
         else
             echo "Failed to convert '${ts_file}'."
+            rm -f "${part_file}"
+            mark_failed "${ts_file}"
         fi
     done
 
     echo "Conversion process completed."
 }
 
-# Convert .ts files to .mp4 after downloading
-convert_ts_to_mp4
+while true; do
+    convert_ts_to_mp4
 
-echo "All tasks completed successfully. Sleeping for $SLEEPTIME seconds..."
-sleep $SLEEPTIME
+    if [ "${RUN_ONCE}" = "true" ]; then
+        echo "RUN_ONCE=true; exiting after one conversion pass."
+        exit 0
+    fi
+
+    echo "All tasks completed successfully. Sleeping for ${SLEEPTIME} seconds..."
+    sleep "${SLEEPTIME}"
+done

--- a/test_entrypoint.sh
+++ b/test_entrypoint.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+write_fake_ffmpeg() {
+  local fakebin="$1"
+  local exit_code="$2"
+  local output_text="$3"
+
+  cat > "${fakebin}/ffmpeg" <<FAKE_FFMPEG
+#!/usr/bin/env sh
+format=""
+out=""
+previous=""
+for arg in "\$@"; do
+  if [ "\$previous" = "-f" ]; then
+    format="\$arg"
+  fi
+  if [ "\$arg" != "-y" ] && [ "\$previous" != "-i" ] && [ "\$previous" != "-c" ] && [ "\$previous" != "-f" ] && [ "\$arg" != "-i" ] && [ "\$arg" != "-c" ] && [ "\$arg" != "copy" ] && [ "\$arg" != "-f" ]; then
+    out="\$arg"
+  fi
+  previous="\$arg"
+done
+
+case "\$out" in
+  *.mp4|*.m4v) ;;
+  *)
+    if [ "\$format" != "mp4" ]; then
+      echo "Unable to choose an output format for '\$out'" >&2
+      exit 1
+    fi
+    ;;
+esac
+
+printf '${output_text}' > "\$out"
+exit ${exit_code}
+FAKE_FFMPEG
+  chmod +x "${fakebin}/ffmpeg"
+}
+
+test_failed_conversion_marks_ts_failed_and_removes_partial_mp4() {
+  local tmpdir fakebin workdir
+  tmpdir="$(mktemp -d)"
+  fakebin="${tmpdir}/bin"
+  workdir="${tmpdir}/downloads"
+  mkdir -p "${fakebin}" "${workdir}"
+  write_fake_ffmpeg "${fakebin}" 137 "partial output"
+
+  printf 'video data' > "${workdir}/broken.ts"
+
+  PATH="${fakebin}:${PATH}" WORKDIR="${workdir}" SLEEPTIME=0 RUN_ONCE=true "${repo_root}/entrypoint.sh" >/tmp/ffmpeg-test.log 2>&1
+
+  test -f "${workdir}/broken.ts.failed"
+  test ! -f "${workdir}/broken.ts"
+  test ! -f "${workdir}/broken.mp4.part"
+
+  rm -rf "${tmpdir}"
+}
+
+test_failed_conversion_preserves_existing_mp4() {
+  local tmpdir fakebin workdir
+  tmpdir="$(mktemp -d)"
+  fakebin="${tmpdir}/bin"
+  workdir="${tmpdir}/downloads"
+  mkdir -p "${fakebin}" "${workdir}"
+  write_fake_ffmpeg "${fakebin}" 137 "partial output"
+
+  printf 'video data' > "${workdir}/existing.ts"
+  printf 'previous good output' > "${workdir}/existing.mp4"
+
+  PATH="${fakebin}:${PATH}" WORKDIR="${workdir}" SLEEPTIME=0 RUN_ONCE=true "${repo_root}/entrypoint.sh" >/tmp/ffmpeg-test.log 2>&1
+
+  test -f "${workdir}/existing.ts.failed"
+  test -f "${workdir}/existing.mp4"
+  grep -q 'previous good output' "${workdir}/existing.mp4"
+  test ! -f "${workdir}/existing.mp4.part"
+
+  rm -rf "${tmpdir}"
+}
+
+test_successful_conversion_moves_part_to_mp4_and_removes_ts() {
+  local tmpdir fakebin workdir
+  tmpdir="$(mktemp -d)"
+  fakebin="${tmpdir}/bin"
+  workdir="${tmpdir}/downloads"
+  mkdir -p "${fakebin}" "${workdir}"
+  write_fake_ffmpeg "${fakebin}" 0 "complete output"
+
+  printf 'video data' > "${workdir}/good.ts"
+
+  PATH="${fakebin}:${PATH}" WORKDIR="${workdir}" SLEEPTIME=0 RUN_ONCE=true "${repo_root}/entrypoint.sh" >/tmp/ffmpeg-test.log 2>&1
+
+  test -f "${workdir}/good.mp4"
+  grep -q 'complete output' "${workdir}/good.mp4"
+  test ! -f "${workdir}/good.mp4.part"
+  test ! -f "${workdir}/good.ts"
+  test ! -f "${workdir}/good.ts.failed"
+
+  rm -rf "${tmpdir}"
+}
+
+test_failed_conversion_marks_ts_failed_and_removes_partial_mp4
+test_failed_conversion_preserves_existing_mp4
+test_successful_conversion_moves_part_to_mp4_and_removes_ts
+
+echo "entrypoint tests passed"


### PR DESCRIPTION
## Summary
- Handle FFmpeg conversion failures without letting restart policies retry the same `.ts` forever.
- Write to `.mp4.part`, force MP4 muxing with `-f mp4`, then move to `.mp4` on success.
- On failure, remove partial output and rename the source `.ts` to `.ts.failed` while preserving any existing `.mp4`.
- Add shell tests for failed conversion cleanup, preserving existing `.mp4`, and successful conversion.
- Document failure handling and recommend 512M+ memory for large remuxes.

## Test Plan
- [x] `sh -n entrypoint.sh`
- [x] `bash -n test_entrypoint.sh`
- [x] `./test_entrypoint.sh`
- [x] `git diff --check origin/main..HEAD`

Related: liofal/streamlink#40